### PR TITLE
RK-915 - Auth dont fail cors requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@sentry/electron": "^0.8.1",
     "args-parser": "^1.1.0",
     "auto-launch": "^5.0.5",
+    "cors": "^2.8.5",
     "electron-log": "^2.2.15",
     "electron-store": "^2.0.0",
     "electron-updater": "^2.21.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { GraphQLServer } from "graphql-yoga";
 import { join } from "path";
+import * as cors from "cors";
 import { resolvers } from "./api";
 import { Request, Response, NextFunction } from "express";
 import { logMiddleware, filterDirTraversal, resolveRepoFromId } from "./middlewares";
@@ -13,7 +14,7 @@ export const start = (accessToken: string, port: number = 44512) => {
     middlewares: [logMiddleware, resolveRepoFromId, filterDirTraversal],
   });
 
-  server.express.use((req: Request, res: Response, next: NextFunction) => {
+  server.express.use(cors(), (req: Request, res: Response, next: NextFunction) => {
     if (process.env.EXPLOROOK_NOAUTH) {
       next();
       return;


### PR DESCRIPTION
Previous middleware failed the request too soon, even a cors preflight `OPTIONS` request would've failed  
And that led to FE error "Failed to fetch" and FE couldn't know the difference between bad token and no connection
Need this one to go in first https://github.com/Rookout/frontend/pull/580  
Otherwise, we will get a lot of error logs