### PR TITLE
RK-1445 - Fix git repo naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,7 +4,7 @@ import _ = require("lodash");
 import parseRepo = require("parse-repo");
 import path = require("path");
 // for normalization of windows paths to linux style paths
-import slash from "slash";
+import slash = require("slash");
 import { Repository } from "./common/repository";
 import { notify } from "./exceptionManager";
 const uuidv4 = require("uuid/v4");
@@ -25,6 +25,11 @@ export async function getRepoId(repo: Repository, idList: string[]): Promise<str
         }
         return repoId;
     } catch (error) {
+        if (error && !error.toString().includes("Unable to find git root for")) {
+            notify("Failed to generate repo id from git", {
+                metaData: { error, repo }
+            })
+        }
         // no git found
         return uuidv4();
     }

--- a/src/slash.d.ts
+++ b/src/slash.d.ts
@@ -1,1 +1,4 @@
-declare module 'slash';
+declare module "slash" {
+    function Slash(str: string): string;
+    export = Slash;
+}


### PR DESCRIPTION
The problem was a bad import of the `slash` package.  
We use the `slash` package to normalize windows path slashes with Unix's path slashes (e.g "\" -> "/").  
The use of slash here got in ~20days ago as part of a fix for Ori Shoshan's friend who had troubles with inner folders in Windows.  
The fact that I used the wrong import syntax, together with the fact that the `slash` package is untyped caused a runtime error that got swallowed by a generic try-catch.  
The original catch was legit because if the folder isn't a git repository an exception is popped by our git third party module (aka `isomorphic-git`).  
Of course, it was just a matter of time this try-catch will catch a legitimate error and ignore it silently.  
Therefore, I:
1. I declared the exact types of the slash module so that typescript will know exactly how the slash module looks/behaves
1. I fixed the bad import
1. I added a log when the error isn't the expected "no git repo"