### PR TITLE
RK-1649 Generate release notes trigger from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,10 @@ jobs:
     docker:
       - image: node:8-alpine
     steps:
+      - checkout
       - run:
           name: Get version from package.json
-          command: echo EXPLOROOK_VERSION=$(npm version | grep -E "explorook: '\d+.\d+.\d+'" | grep -Eo "\d+.\d+.\d+") >> $BASH_ENV
+          command: echo "export EXPLOROOK_VERSION=$(node -e 'console.log(require(\"./package\").version)')" >> $BASH_ENV
       - run:
           name: Generate release notes
           command: curl -X POST https://github-enforcer.rookout.com/release -H 'Content-Type: application/json' -H 'X-Enforcer-Signature: $ENFORCER_SECRET' -d '{"repository":{"full_name":"Rookout/explorook"},"data":{"inner_version":"v$EXPLOROOK_VERSION","version_to_publish":"$EXPLOROOK_VERSION","component":"explorook","released_by":"CircleCI"}}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             (brew install wine || brew install wine)
             # install yarn
             npm install -g yarn
-            # install electron main window dependencies 
+            # install electron main window dependencies
             yarn
             # build code (mostly compile typescript)
             yarn run build
@@ -54,7 +54,17 @@ jobs:
       - run:
           name: Validate version has no release yet
           command: sh ./validate_version.sh
-      
+  publish_release_notes:
+    docker:
+      - image: node:8-alpine
+    steps:
+      - run:
+          name: Get version from package.json
+          command: echo EXPLOROOK_VERSION=$(npm version | grep -E "explorook: '\d+.\d+.\d+'" | grep -Eo "\d+.\d+.\d+") >> $BASH_ENV
+      - run:
+          name: Generate release notes
+          command: curl -X POST https://github-enforcer.rookout.com/release -H 'Content-Type: application/json' -H 'X-Enforcer-Signature: $ENFORCER_SECRET' -d '{"repository":{"full_name":"Rookout/explorook"},"data":{"inner_version":"v$EXPLOROOK_VERSION","version_to_publish":"$EXPLOROOK_VERSION","component":"explorook","released_by":"CircleCI"}}'
+
 workflows:
   version: 2
   publish-pipeline:
@@ -65,3 +75,6 @@ workflows:
       - publish:
           requires:
             - version_validation
+      - publish_release_notes:
+          requires:
+            - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ jobs:
           command: echo "export EXPLOROOK_VERSION=$(node -e 'console.log(require(\"./package\").version)')" >> $BASH_ENV
       - run:
           name: Generate release notes
-          command: curl -X POST https://github-enforcer.rookout.com/release -H 'Content-Type: application/json' -H 'X-Enforcer-Signature: $ENFORCER_SECRET' -d '{"repository":{"full_name":"Rookout/explorook"},"data":{"inner_version":"v$EXPLOROOK_VERSION","version_to_publish":"$EXPLOROOK_VERSION","component":"explorook","released_by":"CircleCI"}}'
+          command: |
+            curl -X POST https://github-enforcer.rookout.com/release -H 'Content-Type: application/json' -H 'X-Enforcer-Signature: $ENFORCER_SECRET' -d '{"repository":{"full_name":"Rookout/explorook"},"data":{"inner_version":"v$EXPLOROOK_VERSION","version_to_publish":"$EXPLOROOK_VERSION","component":"explorook","released_by":"CircleCI"}}'
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
@amits1995 Things to think about --> If we fetch from somewhere something from the release page of this repo it will need filtering as there will be 2 releases/tags for each version, 1 from your publishing, 1 from github-enforcer with the formatted release notes.

I can potentially fix that with a check in the enforcer to see if its explorook and do things differently.

#.2 -> Do I need to increment version in package.json for changes in CI?