### PR TITLE
RK-4124 - Add rookout-dev to cors domain whitelist

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ const defaultOptions: StartOptions = {
 
 const corsDomainWhitelist = [
     /^https:\/\/.*\.rookout.com$/,
+    /^https:\/\/.*\.rookout-dev.com$/,
     "https://localhost:8080"
 ];
 


### PR DESCRIPTION
Required for branches as it is the only source possibility