### PR TITLE
RK-6250 Open explorook on double click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {
@@ -53,7 +53,6 @@
         "Rookout LTD"
       ],
       "target": "NSIS",
-      "sign": "./sign_windows.js",
       "icon": "assets/icons/logo@512x512.png"
     }
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "Rookout LTD"
       ],
       "target": "NSIS",
+      "sign": "./sign_windows.js",
       "icon": "assets/icons/logo@512x512.png"
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,7 @@ function openTray() {
   ]);
   tray.setToolTip("Rookout");
   tray.setContextMenu(contextMenu);
+  tray.on("double-click", maximize);
   if (process.platform.match("darwin")) {
     tray.on("right-click", (e) => tray.popUpContextMenu());
   }

--- a/src/perforceManager.ts
+++ b/src/perforceManager.ts
@@ -162,8 +162,8 @@ class PerforceManager {
     }
 
     public async getChangelistForFile(fullPath: string): Promise<string> {
-        const workspaces = (await this.p4.cmd("workspaces"))?.stat;
         const client = this.getCurrentClient();
+        const workspaces = (await this.p4.cmd(`workspaces -u ${client.Owner}`))?.stat;
         const workspace = _.find<IPerforceWorkspace | null>(workspaces,
            ws => (fullPath.includes(ws.Root) && client.Owner === ws.Owner));
         if (workspace) {

--- a/src/perforceManager.ts
+++ b/src/perforceManager.ts
@@ -55,8 +55,8 @@ class PerforceManager {
         if (!client || client.Client === currentRookoutClientName) {
           return;
         }
-        // Check if workspace exists. If not, create it.
-        const allWorkspaces = this.p4.cmdSync("workspaces")?.stat;
+        // Check if workspace exists. If not, create it. Only get this user's workspaces.
+        const allWorkspaces = this.p4.cmdSync(`workspaces -u ${client.Owner}`)?.stat;
         if (!_.find(allWorkspaces, workspace => workspace.Client === currentRookoutClientName)) {
             // Creating a new client for Rookout desktop app without own root so we can change depots when needed
             const newClient = { ...client, Client: currentRookoutClientName };


### PR DESCRIPTION
A customer complained that when he double clicks the tray icon we don't open the config. Fixed.
Also to save PRs I changed it here: Only get workspaces owned by this specific user to make sure we don't get a timeout.