### PR TITLE
RK-6483 - more performant git cloning in current method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Cloning and fetching with `--depth=1` to avoid downloading full repo history