### PR TITLE
RK-7014 - ignore dll and pdb files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/fsIndexer.ts
+++ b/src/fsIndexer.ts
@@ -7,7 +7,7 @@ const walk = require("walk");
 const defaultIgnores = [/\.git/, /\.svn/, /\.hg/, /CVS/, /\.DS_Store/,
     /site\-packages/, /node_modules/, /bower_components/, /\.venv/, /\.idea/,
     /\.project/, /\.cache/, /\.gradle/, /\.idea/, /\.kube/, /\.vscode/, /\.history/, /\.eggs/];
-const ignoreRegex = /.*(\.pyc|\.class|\.jar|\.svg|\.png|\.mxml|\.html|\.css|\.scss)$/i;
+const ignoreRegex = /.*(\.pyc|\.class|\.jar|\.svg|\.png|\.mxml|\.html|\.css|\.scss|\.dll|\.pdb)$/i;
 // TODO: check performance to the limit and increase as necessary
 const listLimit = 50000;
 

--- a/src/fsIndexer.ts
+++ b/src/fsIndexer.ts
@@ -7,7 +7,7 @@ const walk = require("walk");
 const defaultIgnores = [/\.git/, /\.svn/, /\.hg/, /CVS/, /\.DS_Store/,
     /site\-packages/, /node_modules/, /bower_components/, /\.venv/, /\.idea/,
     /\.project/, /\.cache/, /\.gradle/, /\.idea/, /\.kube/, /\.vscode/, /\.history/, /\.eggs/];
-const ignoreRegex = /.*(\.pyc|\.class|\.jar|\.svg|\.png|\.mxml|\.html|\.css|\.scss|\.dll|\.pdb)$/i;
+const ignoreRegex = /.*(\.pyc|\.class|\.jar|\.svg|\.png|\.mxml|\.html|\.css|\.scss|\.dll|\.pdb|\.exe|\.csproj)$/i;
 // TODO: check performance to the limit and increase as necessary
 const listLimit = 50000;
 


### PR DESCRIPTION
Ignore more meta files when indexing .NET projects  
[reference](https://app.bugsnag.com/rookout/explorook/errors/5f3be7b0c58ab9001727e113?filters[event.since][0][type]=eq&filters[event.since][0][value]=7d&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[app.release_stage][0][type]=eq&filters[app.release_stage][0][value]=production)