### PR TITLE
RK-7375 - Bugsnag improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exceptionManager.ts
+++ b/src/exceptionManager.ts
@@ -1,12 +1,16 @@
 import { Client, INotifyOpts, NotifiableError } from "@bugsnag/core";
 const bugsnag = require("@bugsnag/js");
 const electron = require('electron');
-const app = electron.app || electron.remote.app;
+let app: Electron.App;
+// check if not running in headless mode (plain nodejs process)
+if (typeof electron !== 'string') {
+  app = electron.app || electron.remote.app;
+}
 
 let exceptionManagerInstance: Client;
 
 export const initExceptionManager = (getUserID: () => string) => {
-    if (!exceptionManagerInstance) {
+    if (!exceptionManagerInstance && app) {
       const releaseStage = app.isPackaged ? 'production' : 'development';
       exceptionManagerInstance = bugsnag({
         onUncaughtException: (err: any) => {

--- a/src/index-worker.ts
+++ b/src/index-worker.ts
@@ -9,7 +9,6 @@ import {getLogger, setLogLevel} from "./logger";
 import {changePerforceManagerSingleton, PerforceConnectionOptions} from "./perforceManager";
 import { repStore } from "./repoStore";
 import * as graphQlServer from "./server";
-import {getStoreSafe} from "./explorook-store";
 
 let mainWindowId = -1;
 
@@ -29,10 +28,7 @@ const isPortInUse = (port: number): Promise<boolean> => new Promise<boolean>((re
 
 ipcRenderer.once("exception-manager-enabled-changed", (e: IpcRendererEvent, enabled: boolean) => {
     if (enabled) {
-        initExceptionManager(
-          remote.process.env.development ? "development" : "production",
-          remote.app.getVersion(),
-          () => ipcRenderer.sendSync("get-user-id"));
+        initExceptionManager(() => ipcRenderer.sendSync("get-user-id"));
     }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ function registerIpc() {
   });
   ipcMain.on("signed-eula", (e: IpcMainEvent) => {
     if (dataCollectionEnabled || process.env.development) {
-      initExceptionManager(process.env.development ? "development" : "production", app.getVersion(), () => userId);
+      initExceptionManager(() => userId);
       initAnalytics();
       track("signed-eula");
     }
@@ -222,7 +222,7 @@ function main() {
   dataCollectionEnabled = store.get("sentry-enabled", true);
   signedEula = store.get("has-signed-eula", false);
   if (signedEula && (dataCollectionEnabled || process.env.development)) {
-    initExceptionManager(process.env.development ? "development" : "production", app.getVersion(), () => userId);
+    initExceptionManager(() => userId);
     initAnalytics();
   }
 
@@ -259,6 +259,10 @@ async function update() {
     return;
   }
   console.log("will try to update");
+  autoUpdater.on('error', error => {
+    console.log('gotcha', error)
+    notify(error)
+  })
   let updateInterval: NodeJS.Timer = null;
   autoUpdater.signals.updateDownloaded((info: UpdateInfo) => {
     willUpdateOnClose = true;


### PR DESCRIPTION
1. errors are grouped by the file they were thrown from: with `projectRoot` the different filesystems should have similar relative filenames and grouping should be better
1. I changed how we catch errors from autoUpdater - now we get the error object instead of an string with the error.
1. I improved the detection of environment (dev/prod)