### PR TITLE
RK-7625 - GitOnPrem // do not clone dups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -160,10 +160,8 @@ export const resolvers = {
       let updatedSourcesArray = _.cloneDeep(args.sources);
       if (!_.isEmpty(duplicates)) {
         _.forEach(duplicates, dup => {
-          const firstSourceToKeep = _.find(updatedSourcesArray, src => src.repoUrl === dup);
           // @ts-ignore
-          updatedSourcesArray = _.filter(updatedSourcesArray, src => src.repoUrl !== dup);
-          updatedSourcesArray.push(firstSourceToKeep);
+          updatedSourcesArray = _.uniqBy(args.sources, src => src.repoUrl)
         });
       }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -157,13 +157,7 @@ export const resolvers = {
       // If we have the same remote origin with two different commits we will take the first one only.
       const duplicates = _.keys(_.pickBy(_.groupBy(args.sources, "repoUrl"), d => d.length > 1));
       logger.debug("Found duplicate repos", duplicates);
-      let updatedSourcesArray = _.cloneDeep(args.sources);
-      if (!_.isEmpty(duplicates)) {
-        _.forEach(duplicates, dup => {
-          // @ts-ignore
-          updatedSourcesArray = _.uniqBy(args.sources, src => src.repoUrl)
-        });
-      }
+      const updatedSourcesArray = _.uniqBy(args.sources, src => src.repoUrl);
 
       const addRepoPromises = _.map(updatedSourcesArray, async repo => {
         context.updateGitLoadingState(true, repo.repoUrl);

--- a/src/git.ts
+++ b/src/git.ts
@@ -207,15 +207,7 @@ export async function isGitFolderBiggerThanMaxSize(): Promise<{ sizeOverMaxSize:
     const failedFolders: string[] = [];
     const isDirectory = (source: string) => fs.lstatSync(source).isDirectory();
 
-    const rootDirContent = _.map(fs.readdirSync(GIT_ROOT), dirName => {
-        const subdir = path.join(GIT_ROOT, dirName);
-        if (dirName.includes(TMP_DIR_PREFIX)) {
-            const duplicatedRepoDir = _.head(fs.readdirSync(subdir));
-            return path.join(subdir, duplicatedRepoDir);
-        }
-
-        return subdir;
-    });
+    const rootDirContent = _.map(fs.readdirSync(GIT_ROOT), dirName => path.join(GIT_ROOT, dirName));
     logger.debug("Checking root dir size", rootDirContent);
 
     const repoDirs = _.filter(rootDirContent, isDirectory);

--- a/src/git.ts
+++ b/src/git.ts
@@ -167,40 +167,36 @@ const getProtocolFromStore = () => {
     return parseInt(protocol, 10);
 };
 
-export async function cloneRemoteOriginWithCommit(repoUrl: string, commit: string, isDuplicate: boolean) {
+export async function cloneRemoteOriginWithCommit(repoUrl: string, commit: string) {
     const canAuthRes = await canAuthGitRepo(repoUrl);
     if (!canAuthRes.querySuccessful) {
       logger.warn(`UNAUTHORIZED to remote`, { repoUrl, commit });
       return null;
     }
     repoUrl = convertUrlToProtocol(repoUrl, canAuthRes.protocol);
-    logger.debug("Cloning repo", {repoUrl, commit, isDuplicate});
+    logger.debug("Cloning repo", { repoUrl, commit });
     const protocol = getProtocolFromStore();
     const formattedRepoUri = convertUrlToProtocol(repoUrl, protocol);
     logger.debug("Uri formatted", formattedRepoUri);
 
     // Assuming the last part of the remote origin url is the name of the repo.
     const repoName = parseRepo(formattedRepoUri).project;
-     // If we have two of the same git remote with a different commit we want to create a sub directory.
-    const gitRoot = isDuplicate ? path.join(GIT_ROOT, `${TMP_DIR_PREFIX}${uuidv4()}`) : GIT_ROOT;
-     // Create the sub directory if needed.
-    if (isDuplicate) fs.mkdirSync(gitRoot);
 
      // Getting the full path of the repo, including the repo name.
-    const repoDir = path.join(gitRoot, repoName);
+    const repoDir = path.join(GIT_ROOT, repoName);
 
      // If the folder already exists we don't need to clone, just checkout.
     const doesRepoExist = fs.existsSync(repoDir);
 
     if (doesRepoExist) {
-      logger.debug("fetching latest code", { gitRoot, doesRepoExist });
-      await exec("git fetch", { cwd: repoDir, maxBuffer: TEN_MEGABYTE })
+      logger.debug("fetching latest code", { GIT_ROOT, doesRepoExist });
+      await exec("git fetch", { cwd: repoDir, maxBuffer: TEN_MEGABYTE });
     } else {
-      logger.debug("cloning into", { gitRoot, doesRepoExist });
-      await exec(`git clone ${formattedRepoUri}`, { cwd: gitRoot, maxBuffer: TEN_MEGABYTE })
+      logger.debug("cloning into", { GIT_ROOT, doesRepoExist });
+      await exec(`git clone ${formattedRepoUri}`, { cwd: GIT_ROOT, maxBuffer: TEN_MEGABYTE });
     }
-    logger.debug(`checking out to commit ${commit}`, { commit, gitRoot, doesRepoExist });
-    await exec(`git checkout ${commit}`, { cwd: repoDir, maxBuffer: TEN_MEGABYTE })
+    logger.debug(`checking out to commit ${commit}`, { commit, GIT_ROOT, doesRepoExist });
+    await exec(`git checkout ${commit}`, { cwd: repoDir, maxBuffer: TEN_MEGABYTE });
     return repoDir;
 }
 // 10GB

--- a/src/index-worker.ts
+++ b/src/index-worker.ts
@@ -105,7 +105,7 @@ ipcRenderer.on("test-perforce-connection", (e: IpcRendererEvent, connectionOptio
 ipcRenderer.on("test-git-connection", async (e: IpcRendererEvent, connectionOptions: GitConnectionOptions) => {
     let isSuccess = false;
     try {
-      isSuccess = !!(await cloneRemoteOriginWithCommit(connectionOptions.connectionString, "master", false));
+      isSuccess = !!(await cloneRemoteOriginWithCommit(connectionOptions.connectionString, "master"));
     } catch (e) {
       notify(e, { metaData: { extra: { message: "Cannot clone remote origin", connectionOptions } } });
       console.error(`Failed to clone git repo ${connectionOptions.connectionString}`, e);


### PR DESCRIPTION
if the getGitRepo mutation gets duplicates (same git origin, different commit) take the first one and clone only it. (or fetch and checkout if exists).
the previous behavior was to create separated folders and clone each dup.