### PR TITLE
Bitbucket op/max file size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.7.25",
+  "version": "1.7.26",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Now using BitBucket Server's pagination to get files longer than 500 lines