### PR TITLE
Java Extension: Remove semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.7.26",
+  "version": "1.7.27",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "parse-repo": "^1.0.4",
     "patch-package": "^6.2.2",
     "postinstall-postinstall": "^2.1.0",
-    "semver": "^7.3.4",
     "slash": "^2.0.0",
     "url-assembler": "^2.1.1",
     "uuid": "^3.2.1",

--- a/src/langauge-servers/javaUtils.ts
+++ b/src/langauge-servers/javaUtils.ts
@@ -153,7 +153,14 @@ const parseMajorVersion = (version: string): number => {
     }
 
     try {
-        return semver.major(version);
+        // Using this instead of semver because Java is NOT semantic versioned, e.g '8.0_202' is a valid java version but it is not semantic
+        const regexp = /\d+/g;
+        const match = regexp.exec(version);
+        let javaVersion = 0;
+        if (match) {
+            javaVersion = parseInt(match[0]);
+        }
+        return javaVersion;
     } catch (e) {
         logger.error('version cannot be parsed', { version })
         return 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4940,13 +4940,6 @@ lru-cache@^5.0.0, lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 make-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -6773,13 +6766,6 @@ semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
-  dependencies:
-    lru-cache "^6.0.0"
-
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -8166,11 +8152,6 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^13.1.0:
   version "13.1.1"


### PR DESCRIPTION
Removed Semver from java utils, that's because java versions are NOT semantic versions.
My mac had version 8.0_202, which isn't semantic so it threw an exception.

Semver is a strict one, I suggest you try it out: https://npm.runkit.com/ ,it will throw exception for '7.0' for example.
So I went for a more natural way, which was taken from RedHat's own Java langserver vscode extension.