### PR TITLE
RK-9018 - Langservers: Save langserver to appdata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.7.28",
+  "version": "1.7.27",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.7.27",
+  "version": "1.7.28",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/langauge-servers/configStore.ts
+++ b/src/langauge-servers/configStore.ts
@@ -1,13 +1,15 @@
+import { getLibraryFolder } from './../utils';
 import { getStoreSafe, IStore } from './../explorook-store';
 import { getLogger } from './../logger';
 import { findJavaHomes, getJavaVersion } from './javaUtils';
 import * as fs from 'fs'
 import * as https from 'https'
+import * as path from 'path'
 import _ = require('lodash')
 
-export const logger = getLogger('langerServer')
+export const logger = getLogger('langServer')
 export const JavaLangServerDownloadURL = 'https://get.rookout.com/Language-Servers/Rookout-Java-Language-Server.jar'
-export const javaLangServerJarLocation = 'Rookout-Java-Language-Server.jar'
+export const javaLangServerJarLocation = path.join(getLibraryFolder(), 'languageServers', 'java', 'Rookout-Java-Language-Server.jar')
 export const minimumJavaVersionRequired = 13
 
 class LangServerConfigStore {
@@ -28,14 +30,19 @@ class LangServerConfigStore {
     }
 
     public doesJavaJarExist(): boolean {
-        return fs.existsSync(javaLangServerJarLocation)
+        try {
+            return fs.existsSync(javaLangServerJarLocation)
+        } catch (e) {
+            logger.error(e)
+            return false
+        }
     }
 
     // Java ls is about 2.1MB, so expecting a very quick download time
     private downloadJavaLangServer = async () => {
         this.isDownloadingJavaJar = true
 
-        logger.debug('downloading Java LS from ' + JavaLangServerDownloadURL)
+        logger.info('downloading Java LS from ' + JavaLangServerDownloadURL)
 
         const file = fs.createWriteStream(javaLangServerJarLocation);
         https.get(JavaLangServerDownloadURL, (response) => {
@@ -48,7 +55,7 @@ class LangServerConfigStore {
             response.pipe(file);
             file.on('finish', () => file.close())
             this.isDownloadingJavaJar = false
-            logger.debug('Java - Langserver downloaded successfully')
+            logger.info('Java - Langserver downloaded successfully')
             
             return true
         })

--- a/src/langauge-servers/configStore.ts
+++ b/src/langauge-servers/configStore.ts
@@ -1,15 +1,13 @@
-import { getLibraryFolder } from './../utils';
 import { getStoreSafe, IStore } from './../explorook-store';
 import { getLogger } from './../logger';
 import { findJavaHomes, getJavaVersion } from './javaUtils';
 import * as fs from 'fs'
 import * as https from 'https'
-import * as path from 'path'
 import _ = require('lodash')
 
-export const logger = getLogger('langServer')
+export const logger = getLogger('langerServer')
 export const JavaLangServerDownloadURL = 'https://get.rookout.com/Language-Servers/Rookout-Java-Language-Server.jar'
-export const javaLangServerJarLocation = path.join(getLibraryFolder(), 'languageServers', 'java', 'Rookout-Java-Language-Server.jar')
+export const javaLangServerJarLocation = 'Rookout-Java-Language-Server.jar'
 export const minimumJavaVersionRequired = 13
 
 class LangServerConfigStore {
@@ -30,19 +28,14 @@ class LangServerConfigStore {
     }
 
     public doesJavaJarExist(): boolean {
-        try {
-            return fs.existsSync(javaLangServerJarLocation)
-        } catch (e) {
-            logger.error(e)
-            return false
-        }
+        return fs.existsSync(javaLangServerJarLocation)
     }
 
     // Java ls is about 2.1MB, so expecting a very quick download time
     private downloadJavaLangServer = async () => {
         this.isDownloadingJavaJar = true
 
-        logger.info('downloading Java LS from ' + JavaLangServerDownloadURL)
+        logger.debug('downloading Java LS from ' + JavaLangServerDownloadURL)
 
         const file = fs.createWriteStream(javaLangServerJarLocation);
         https.get(JavaLangServerDownloadURL, (response) => {
@@ -55,7 +48,7 @@ class LangServerConfigStore {
             response.pipe(file);
             file.on('finish', () => file.close())
             this.isDownloadingJavaJar = false
-            logger.info('Java - Langserver downloaded successfully')
+            logger.debug('Java - Langserver downloaded successfully')
             
             return true
         })

--- a/src/langauge-servers/javaUtils.ts
+++ b/src/langauge-servers/javaUtils.ts
@@ -3,7 +3,6 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as cp from 'child_process'
 import * as os from 'os'
-import semver = require('semver')
 import _ = require('lodash')
 
 const logger = getLogger('langserver')

--- a/src/langauge-servers/javaUtils.ts
+++ b/src/langauge-servers/javaUtils.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as cp from 'child_process'
 import * as os from 'os'
+import semver = require('semver')
 import _ = require('lodash')
 
 const logger = getLogger('langserver')


### PR DESCRIPTION
When the explorook is in prod-mode (packaged), its working directory is an unprivileged folder so all downloads should be done in a dedicated folder.

There was an error when trying to check if the file exists, on load so I wrapped it in try/catch for next times.