### PR TITLE
RK-9245 - Fix local clone URI in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/langauge-servers/javaUtils.ts
+++ b/src/langauge-servers/javaUtils.ts
@@ -6,7 +6,7 @@ import * as os from 'os'
 import _ = require('lodash')
 
 const logger = getLogger('langserver')
-const isWindows = process.platform.match('win32')
+export const isWindows = process.platform.match('win32')
 const isMac = process.platform.match('darwin')
 const isLinux = process.platform.match('linux')
 export const JAVA_FILENAME = isWindows ? 'java.exe' : 'java';

--- a/src/langauge-servers/langaugeServer.ts
+++ b/src/langauge-servers/langaugeServer.ts
@@ -1,3 +1,4 @@
+import { isWindows } from './javaUtils';
 import { repStore } from '../repoStore';
 /* --------------------------------------------------------------------------------------------
  * Copyright (c) 2018 TypeFox GmbH (http://www.typefox.io). All rights reserved.
@@ -76,6 +77,9 @@ export const launchLangaugeServer = (socket: rpc.IWebSocket, startConfig: langSe
             }
 
             repoFullpath = encodeURI(repoFullpath);
+            if (isWindows) {
+                repoFullpath = repoFullpath.replace('%5C', '\\');
+            }
             
             // rootUri and rootPath are considered deprecated by the vscode's lsp and they are the only way to indicate 
             // to the language server the workspace folder


### PR DESCRIPTION
the encode URI line - which is necessary to encode spaces in mac - is replacing the backslashes that windows URI has, with its urlencode '%5C'.

The URI is gotten from `igit.findRoot()`