### PR TITLE
RK-9398 RK-9397- better error handling in two places

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/BitBucketOnPrem.ts
+++ b/src/BitBucketOnPrem.ts
@@ -47,6 +47,7 @@ export const getFileTreeFromBitbucket =
         if (Array.isArray(fileList.values)) {
             files = [...files, ...fileList.values];
         } else {
+            notify("Bitbucket OnPrem files tree request returned an unexpected value", { metaData: { resStatus: res.status, fileList } });
             logger.error("Bitbucket OnPrem files tree request returned an unexpected value", { res, fileList });
             return [];
         }

--- a/src/BitBucketOnPrem.ts
+++ b/src/BitBucketOnPrem.ts
@@ -47,7 +47,7 @@ export const getFileTreeFromBitbucket =
         if (Array.isArray(fileList.values)) {
             files = [...files, ...fileList.values];
         } else {
-            logger.error("Bitbucket OnPrem files tree request returned an unexpected value", { res });
+            logger.error("Bitbucket OnPrem files tree request returned an unexpected value", { res, fileList });
         }
 
         // If there are more files than the limit the API is paged. Get the page starting at the end of this request.

--- a/src/BitBucketOnPrem.ts
+++ b/src/BitBucketOnPrem.ts
@@ -48,6 +48,7 @@ export const getFileTreeFromBitbucket =
             files = [...files, ...fileList.values];
         } else {
             logger.error("Bitbucket OnPrem files tree request returned an unexpected value", { res, fileList });
+            return [];
         }
 
         // If there are more files than the limit the API is paged. Get the page starting at the end of this request.

--- a/src/BitBucketOnPrem.ts
+++ b/src/BitBucketOnPrem.ts
@@ -44,7 +44,11 @@ export const getFileTreeFromBitbucket =
             }
         });
         const fileList: any = await res.json();
-        files = [...files, ...fileList.values];
+        if (Array.isArray(fileList.values)) {
+            files = [...files, ...fileList.values];
+        } else {
+            logger.error("Bitbucket OnPrem files tree request returned an unexpected value", { res });
+        }
 
         // If there are more files than the limit the API is paged. Get the page starting at the end of this request.
         isLastPage = fileList.isLastPage;

--- a/src/repoStore.ts
+++ b/src/repoStore.ts
@@ -7,6 +7,7 @@ import parseRepo = require("parse-repo");
 import { Repository } from "./common/repository";
 import { IndexWorker } from "./fsIndexer";
 import { getRepoId } from "./git";
+import {logger} from "./langauge-servers/configStore";
 export class Repo {
     public repoName: string;
     public fullpath: string;
@@ -97,7 +98,7 @@ class RepoStore {
             }
             fs.statSync(repo.fullpath);
         } catch (e) {
-            throw new Error(`Failed to stats repository (${repo.fullpath}) error: ` + e.stack);
+            logger.error("Failed to stats repository", { error: e, path: repo.fullpath });
         }
         if (!repo.id) {
             repo.id = await getRepoId(repo, this.getRepositories().map((r) => r.id));
@@ -139,7 +140,7 @@ class RepoStore {
     public getRepositories(): Repo[] {
         return this.repos;
     }
-    
+
     public getRepoById(id: string): Repo {
         return _.find(this.repos,repo => { return id === repo.id})
     }


### PR DESCRIPTION
1. When querying the file tree, bitbucket OP usually returns array in the values attribute. however, from bugsnag it seems it sometimes doesn't. so when it happens I'm skipping those files and sending to bugsnag the response for further investigation.
https://app.bugsnag.com/rookout/explorook/errors/6053385c1509e100075aa075?filters[event.since][0]=30d&filters[error.status][0]=open

2. we're throwing an unhandled error when fs cannot find a path in the computer. logger.error() would be more fitting.
https://app.bugsnag.com/rookout/explorook/errors/5fa3b18786944c001777aa04?filters[event.since][0]=30d&filters[error.status][0]=open