### PR TITLE
RK-10119 - Optional chaining for user query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/BitBucketOnPrem.ts
+++ b/src/BitBucketOnPrem.ts
@@ -84,7 +84,7 @@ export const getUserFromBitbucket = async ({url, accessToken}: BitbucketOnPrem) 
     });
     const users = await res.json();
     logger.debug("finished getting users from url", {url, users});
-    return users.values[0];
+    return users?.values?.[0];
 };
 
 export const getProjectsFromBitbucket = async ({url, accessToken}: BitbucketOnPrem) => {


### PR DESCRIPTION
Added optional chaining to user query from BitbucketOnPrem. Trying to prevent [this](https://app.bugsnag.com/rookout/explorook/errors/6114ec940d80850007572584?event_id=6114ec94007f87a5a0420000&i=sk&m=nw) exception that was reported in bugsnag