### PR TITLE
RK-10496 - RK-10496 - Temp Fix CircleCI cert problem on macOS script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
             echo $GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 | base64 --decode > gcloud_service_account.json
             export GOOGLE_APPLICATION_CREDENTIALS=gcloud_service_account.json
             gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+            ### temp-fix - REVERT ONCE POSSIBLE ###
+            # manually fetch updated certificate bundle from cURL project
+            curl -k https://curl.se/ca/cacert.pem -o ~/.cacert.pem # -k means skip ssl validation since it is a chicken-and-egg situation
+            export CURL_CA_BUNDLE=~/.cacert.pem
+            ###
             # download custom jsign to sign PE
             curl -fsSL https://get.rookout.com/jsign-rookout.jar --output jsign.jar
             # install electron main window dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             #IdenTrust Commercial Root CA 1
             curl -L https://www.identrust.com/node/1330 -o IdenTrustCommercialRootCA.p7b
             #convert to pem
-            openssl pkcs7 -in ~/Downloads/IdenTrustCommercialRootCA.p7b -inform DER -print_certs -out cert.pem            
+            openssl pkcs7 -in IdenTrustCommercialRootCA.p7b -inform DER -print_certs -out cert.pem            
             ###
             # download custom jsign to sign PE
             curl --cacert cert.pem fsSL https://get.rookout.com/jsign-rookout.jar --output jsign.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,15 @@ jobs:
             export GOOGLE_APPLICATION_CREDENTIALS=gcloud_service_account.json
             gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
             ### temp-fix - REVERT ONCE POSSIBLE ###
-            # manually fetch updated certificate bundle from cURL project
-            curl -k https://curl.se/ca/cacert.pem -o ~/.cacert.pem # -k means skip ssl validation since it is a chicken-and-egg situation
-            export CURL_CA_BUNDLE=~/.cacert.pem
+            # manually fetch updated IdenTrustCommercialRootCA (temp fix)
+            # see https://www.identrust.com/support/downloads
+            #IdenTrust Commercial Root CA 1
+            curl -L https://www.identrust.com/node/1330 -o IdenTrustCommercialRootCA.p7b
+            #convert to pem
+            openssl pkcs7 -in ~/Downloads/IdenTrustCommercialRootCA.p7b -inform DER -print_certs -out cert.pem            
             ###
             # download custom jsign to sign PE
-            curl -fsSL https://get.rookout.com/jsign-rookout.jar --output jsign.jar
+            curl --cacert cert.pem fsSL https://get.rookout.com/jsign-rookout.jar --output jsign.jar
             # install electron main window dependencies
             yarn
             # build typescript code


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1862068/136390984-54ebea60-e1c4-4f64-9099-4d9c3b65810e.png)
Explorook CircleCI fails because of not-updated cert bundle that doesn't include the new LetsEncrypt root cert.

~~See [this](https://discuss.circleci.com/t/letsencrypt-ssl-root-cert-problems/41379/9) discussion and the [fix](https://blog.bytesguy.com/resolving-lets-encrypt-issues-with-curl-on-macos) I applied.~~

~~This change should be reverted as soon as possible, I will follow-up on this.~~

Better [fix](https://www.identrust.com/support/downloads)