### PR TITLE
RK-10518 - RK-10518 - Update to node:14.18.0 in circle ci script image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: sh ./validate_version.sh
   publish_release_notes:
     docker:
-      - image: node:8
+      - image: node:14.18.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Another ricochet from [LetEncrypt cert that went RIP](https://discuss.circleci.com/t/letsencrypt-ssl-root-cert-problems/41379): 
Update to node:14.18.0 in circle ci script image to fix it.
Validated locally it fails with node:8, and works for node:14.18.0