### PR TITLE
RK-10826 - Try fixing cache error in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: homebrew-cache-{{ checksum ".circleci/config.yml" }}
+          key: homebrew-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum ".circleci/config.yml" }}
       - run:
           name: Build and Publish
           command: |
@@ -54,7 +54,7 @@ jobs:
             # publish in google storage bucket (additionally to electronbuild-publisher)
             bash upload_release_to_gs.sh
       - save_cache:
-          key: homebrew-cache-{{ checksum ".circleci/config.yml" }}
+          key: homebrew-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - /usr/local/Homebrew
   version_validation:


### PR DESCRIPTION
Something is wrong with the CircleCI cache:
![image](https://user-images.githubusercontent.com/1862068/141958333-bc7a1d97-6ac3-4d25-89a1-d5c12036d606.png)

I added an env var (currently with the value v1) to the cache key so we can bump (v2, v3 ...) it once we want to reset the cache.