### PR TITLE
RK-11221 - Correct broken links to rookout site, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ The Rookout Desktop App was designed with security as a foremost concern, its se
 
 [Learn more about our security standards](https://www.rookout.com/solution/source-code-security/)
 
+## Installation
+
+The desktop app can be installed from within the Rookout web UI, such as when initially selecting a project and indicating use of local code. A link is offered to download the app (which will be customized to your operating system, and which will offer the latest available installer for the Rookout Desktop App). Here's a brief video of that workflow:
+https://youtu.be/watch?v=mkMpzQPNcsI
+
 ## Contributing
 
 There are many ways in which you can participate in the project, for example:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Rookout is a data extraction and pipelining platform, which provides the ability to collect any piece of data from live code, on-demand, using non-breaking breakpoints (Learn more about Rookout on our [website](https://www.rookout.com) or our [docs pages](https://docs.rookout.com)).
 
-The Rookout desktop app allows you to navigate through your local projects in a simple and flexible manner. Use this app in combination with the Rookout web debugger to set non-breaking breakpoints in your source files, and to instantly apply them to live code. 
+The Rookout desktop app ("explorook") allows you to navigate through your local projects in a simple and flexible manner. Use this app in combination with the Rookout web debugger to set non-breaking breakpoints in your source files, and to instantly apply them to live code. 
 
 <p align="center">
   <img src="https://github.com/Rookout/explorook/blob/master/assets/animated-gif.gif" alt="Rookout Desktop App" width="840">

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/rookout/explorook/badge.svg?style=flat-square)](https://snyk.io/test/github/rookout/explorook)
 [![Twitter Follow](https://img.shields.io/twitter/follow/rookoutlabs.svg?style=social)](https://twitter.com/rookoutlabs)
 
-Rookout is a data extraction and pipelining platform, which provides the ability to collect any piece of data from live code, on-demand, using non-breaking breakpoints (Learn more about Rookout on our [website](www.rookout.com) or our [docs pages](docs.rookout.com)).
+Rookout is a data extraction and pipelining platform, which provides the ability to collect any piece of data from live code, on-demand, using non-breaking breakpoints (Learn more about Rookout on our [website](https://www.rookout.com) or our [docs pages](https://docs.rookout.com)).
 
 The Rookout desktop app allows you to navigate through your local projects in a simple and flexible manner. Use this app in combination with the Rookout web debugger to set non-breaking breakpoints in your source files, and to instantly apply them to live code. 
 
@@ -46,7 +46,7 @@ The Rookout Desktop App was designed with security as a foremost concern, its se
 
 There are many ways in which you can participate in the project, for example:
 - [Submit bugs and feature requests](https://github.com/Rookout/explorook/issues), and help us verify as they are checked in.
-- Review the [documentation](docs.rookout.com) and make pull requests for anything from typos to new content. 
+- Review the [documentation](https://docs.rookout.com) and make pull requests for anything from typos to new content. 
 
 If you are interested in fixing issues and contributing directly to the code base, please reach out to support@rookout.com.
 


### PR DESCRIPTION
They were getting 404's, since they lacked the protocol indication.

(I searched for any other similar broken links in MD but found no others.)