### PR TITLE
RK-11600 - Deeplinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.31",
+  "version": "1.8.32",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {
@@ -30,6 +30,10 @@
     ],
     "directories": {
       "output": "installers"
+    },
+    "protocols": {
+      "name": "Rookout",
+      "schemes": ["rookout"]
     },
     "files": [
       "dist",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       "output": "installers"
     },
     "protocols": {
-      "name": "Rookout",
+      "name": "rookout",
       "schemes": ["rookout"]
     },
     "files": [
@@ -45,7 +45,11 @@
     ],
     "linux": {
       "target": "appImage",
-      "category": "Utility"
+      "category": "Utility",
+      "mimeTypes": ["x-scheme-handler/rookout"],
+      "desktop": {
+        "exec": "rookout %u"
+      }
     },
     "dmg": {
       "background": "assets/dmg-background.png"

--- a/src/deeplinks.ts
+++ b/src/deeplinks.ts
@@ -1,0 +1,24 @@
+import {dialog} from "electron";
+
+const path = require("path");
+
+const PROTOCOL = "rookout";
+
+
+
+export const initDeeplinks = (app: Electron.App) => {
+    if (process.defaultApp) {
+        if (process.argv.length >= 2) {
+            app.setAsDefaultProtocolClient(PROTOCOL, process.execPath, [path.resolve(process.argv[1])]);
+        }
+    } else {
+        app.setAsDefaultProtocolClient(PROTOCOL);
+    }
+
+    app.on("open-url", deeplinkHandler);
+};
+
+
+export const deeplinkHandler = () => {
+   dialog.showMessageBoxSync({title: "Rookout Desktop App", message: "Rookout Desktop App is now running"});
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,14 @@ import {autoUpdater, UpdateInfo} from "electron-updater";
 import fs = require("fs");
 import { userInfo } from "os";
 import * as path from "path";
+import {deeplinkHandler, initDeeplinks} from "./deeplinks";
 import { ExplorookStore } from "./explorook-store";
 const uuidv4 = require("uuid/v4");
 import AutoLaunch = require("auto-launch");
 import fetch from "node-fetch";
 import * as os from "os";
 const YAML = require("yaml");
-import { initExceptionManager, notify, Logger } from "./exceptionManager";
+import { initExceptionManager, Logger, notify } from "./exceptionManager";
 
 autoUpdater.logger = new Logger();
 log.transports.console.level = "warn";
@@ -69,7 +70,7 @@ function getAppIcon() {
 
 function getTrayIcon() {
   if (process.platform.match("darwin")) {
-    return "mac/explorook_tray_Template.png"
+    return "mac/explorook_tray_Template.png";
   }
   return getAppIcon();
 }
@@ -212,10 +213,23 @@ async function quitApplication() {
 function main() {
   // check if another instance of this app is already open
   const primary = app.requestSingleInstanceLock();
-  if (!primary) {
+  if (primary) {
+    app.on("second-instance", () => {
+      // Deep link handling for windows is a bit different
+      if (process.platform === "win32") {
+        deeplinkHandler();
+      }
+
+      if (mainWindow) {
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.focus();
+      }
+    });
+  } else {
     quitApplication();
   }
 
+  initDeeplinks(app);
   // store helps us store data on local disk
   store = new ExplorookStore();
   // access token used to access this app's GraphQL api
@@ -263,7 +277,7 @@ async function update() {
     console.log("detected read-only volume - auto update disabled");
     return;
   }
-  autoUpdater.on('error',  async (error) => {
+  autoUpdater.on("error",  async (error) => {
     try {
       // Make sure that GitHub is not available before showing the error message
       const gitHubRes = await fetch("https://github.com/");

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,8 +215,8 @@ function main() {
   const primary = app.requestSingleInstanceLock();
   if (primary) {
     app.on("second-instance", () => {
-      // Deep link handling for windows is a bit different
-      if (process.platform === "win32") {
+      // Deep link handling for windows and linux is a bit different
+      if (["win32", "linux"].includes(process.platform)) {
         deeplinkHandler();
       }
 


### PR DESCRIPTION
Added deeplinks. Now the app can be opened by typing `rookout://` into your address bar in the browser (on Linux it works only when clicking on an `a` element with this `href`)