### PR TITLE
RK-12004 Update appVersion used if remote is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.33",
+  "version": "1.8.34",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,7 +35,6 @@ import {Repo, repStore} from "./repoStore";
 import {loadingStateUpdateHandler, onAddRepoRequestHandler, onRemoveRepoRequestHandler} from "./server";
 import { getSettings, setSettings } from "./utils";
 const folderDelete = require("folder-delete");
-import packageJson from "../package.json";
 
 // using posix api makes paths consistent across different platforms
 const join = posix.join;
@@ -305,12 +304,12 @@ export const resolvers = {
     },
     appVersion: async (parent: any): Promise<string> => {
       if (process.env.development) {
-        return require("../package.json").version;
+        return require("../package.json")?.version;
       } else if (remote) {
         return remote.app.getVersion();
       } else {
         // remote should exist. but sometimes it's undefined and breaks tests for some reason, so adding a temp fallback
-        return packageJson?.version || "1.8.33";
+        return require("../package.json")?.version || "1.8.34";
       }
     },
     recentLogs: (parent: any): Log[] => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -309,7 +309,7 @@ export const resolvers = {
         return remote.app.getVersion();
       } else {
         // remote should exist. but sometimes it's undefined and breaks tests for some reason, so adding a temp fallback
-        return "1.8.16";
+        return "1.8.34";
       }
     },
     recentLogs: (parent: any): Log[] => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,6 +35,7 @@ import {Repo, repStore} from "./repoStore";
 import {loadingStateUpdateHandler, onAddRepoRequestHandler, onRemoveRepoRequestHandler} from "./server";
 import { getSettings, setSettings } from "./utils";
 const folderDelete = require("folder-delete");
+import packageJson from "../package.json";
 
 // using posix api makes paths consistent across different platforms
 const join = posix.join;
@@ -309,7 +310,7 @@ export const resolvers = {
         return remote.app.getVersion();
       } else {
         // remote should exist. but sometimes it's undefined and breaks tests for some reason, so adding a temp fallback
-        return "1.8.34";
+        return packageJson?.version || "1.8.33";
       }
     },
     recentLogs: (parent: any): Log[] => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     ],
     "module": "commonjs",
     "noImplicitAny": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     ],
     "module": "commonjs",
     "noImplicitAny": true,
-    "resolveJsonModule": true,
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",


### PR DESCRIPTION
Try to get appVersion from package json in case remote is empty and if can't fallback to hard coded one.
Bump hard-coded appVersion used in case remote is empty