### PR TITLE
RK-12171 - Support refreshing all git indices with a single request

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -32,6 +32,7 @@ type Query {
   listTree(repoId: String!): [String]!
   listRepos: [Repository!]!
   refreshIndex(repoId: String!): Boolean
+  refreshAllIndices: Boolean
   repository(repoId: String!): Repository!
   getCommitIdForFile(
     provider: OnPremSourceProvider!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.34",
+  "version": "1.8.35",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -284,6 +284,10 @@ export const resolvers = {
       args.repo.reIndex();
       return true;
     },
+    refreshAllIndices(parent: any): boolean {
+      repStore.reAllIndices();
+      return true;
+    },
     getCommitIdForFile: async (parent: any, args: {provider: any, remoteOrigin: string, repo: Repository, path: string}): Promise<string> => {
       logger.debug("Getting commit ID for file", args);
       const {provider, repo, remoteOrigin} = args;

--- a/src/repoStore.ts
+++ b/src/repoStore.ts
@@ -1,10 +1,10 @@
-import { IStore, getStoreSafe } from './explorook-store';
 import { ipcRenderer } from "electron";
 import fs = require("fs");
-import git = require("isomorphic-git");
-import _ = require("lodash");
-import parseRepo = require("parse-repo");
+import _find from "lodash/find";
+import _forEach from "lodash/forEach";
+import _remove from "lodash/remove";
 import { Repository } from "./common/repository";
+import { getStoreSafe, IStore } from "./explorook-store";
 import { IndexWorker } from "./fsIndexer";
 import { getRepoId } from "./git";
 import {logger} from "./langauge-servers/configStore";
@@ -65,7 +65,7 @@ class RepoStore {
     private repos: Repo[];
 
     constructor() {
-        this.store = getStoreSafe()
+        this.store = getStoreSafe();
         const models = JSON.parse(this.store.get("repositories", "[]")) as Repository[];
         this.allowIndex = JSON.parse(this.store.get("allow-indexing", "true"));
         this.repos = [];
@@ -92,7 +92,7 @@ class RepoStore {
 
     public async add(repo: Repository): Promise<string> {
         try {
-            const existingRepo = _.find(this.repos, r => r.fullpath === repo.fullpath);
+            const existingRepo = _find(this.repos, r => r.fullpath === repo.fullpath);
             if (existingRepo) {
                 return existingRepo.id;
             }
@@ -118,7 +118,7 @@ class RepoStore {
     }
 
     public remove(id: string): boolean {
-        const removed = _.remove(this.repos, (r) => r.id === id);
+        const removed = _remove(this.repos, (r) => r.id === id);
         removed.forEach((r) => {
             r.indexer.deleteIndex();
             ipcRenderer.send("track", "repo-remove", { repoName: r.repoName, repoId: r.id });
@@ -142,7 +142,13 @@ class RepoStore {
     }
 
     public getRepoById(id: string): Repo {
-        return _.find(this.repos,repo => { return id === repo.id})
+        return _find(this.repos, repo => id === repo.id);
+    }
+
+    public reAllIndices() {
+        _forEach(this.repos, (repo: Repo) => {
+            repo.reIndex();
+        });
     }
 }
 

--- a/src/repoStore.ts
+++ b/src/repoStore.ts
@@ -1,8 +1,6 @@
 import { ipcRenderer } from "electron";
 import fs = require("fs");
-import _find from "lodash/find";
-import _forEach from "lodash/forEach";
-import _remove from "lodash/remove";
+import _ = require("lodash");
 import { Repository } from "./common/repository";
 import { getStoreSafe, IStore } from "./explorook-store";
 import { IndexWorker } from "./fsIndexer";
@@ -92,7 +90,7 @@ class RepoStore {
 
     public async add(repo: Repository): Promise<string> {
         try {
-            const existingRepo = _find(this.repos, r => r.fullpath === repo.fullpath);
+            const existingRepo = _.find(this.repos, r => r.fullpath === repo.fullpath);
             if (existingRepo) {
                 return existingRepo.id;
             }
@@ -118,7 +116,7 @@ class RepoStore {
     }
 
     public remove(id: string): boolean {
-        const removed = _remove(this.repos, (r) => r.id === id);
+        const removed = _.remove(this.repos, (r) => r.id === id);
         removed.forEach((r) => {
             r.indexer.deleteIndex();
             ipcRenderer.send("track", "repo-remove", { repoName: r.repoName, repoId: r.id });
@@ -142,11 +140,11 @@ class RepoStore {
     }
 
     public getRepoById(id: string): Repo {
-        return _find(this.repos, repo => id === repo.id);
+        return _.find(this.repos, repo => id === repo.id);
     }
 
     public reAllIndices() {
-        _forEach(this.repos, (repo: Repo) => {
+        _.forEach(this.repos, (repo: Repo) => {
             repo.reIndex();
         });
     }


### PR DESCRIPTION
Support refreshing all repo indices at once, instead of sending a separate refresh request for each one.

Tested with an appropriate FE fix.