### PR TITLE
RK-12663 - update ev certificate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             # install dependencies
             yarn --cwd=src/webapp && yarn run --cwd=src/webapp build
             # save windows certificate locally (WIN_CERT) is base64 of our certificate
-            echo $WIN_EV_CERT_BASE64 | base64 --decode > rookout.crt
+            echo $WIN_EV_CERT_BASE64_22 | base64 --decode > rookout.crt
             export WINDOWS_EV_CERTIFICATE_PATH=rookout.crt
             # package code for every distribution (mac, win, linux) and publish as github release
             yarn run build-packages-all-distributions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.39",
+  "version": "1.8.40",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Updated CI to use new EV certificate.
Not hotswapping the secret with the same one, for clarity and making sure we can revert.