### PR TITLE
RK-12657 Fix message pronunciation - add appears twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.40",
+  "version": "1.8.41",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/webapp/src/components/EmptyState.js
+++ b/src/webapp/src/components/EmptyState.js
@@ -7,8 +7,8 @@ export const EmptyState = () => {
       <div style={{ margin: 'auto', display:'flex', flexDirection:'row' }}>
         <img style={{ width: 120, height: 140, paddingRight: 10 }} src={process.env.PUBLIC_URL+"/bird-on-folder.png"}></img>
         <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <Text style={{ marginBottom: "5px", marginTop: "55px" }}>Sweet! Rookout desktop app is up and</Text>
-          <Text style={{ marginTop: 0 }}>and running in the background</Text>
+          <Text style={{ marginBottom: "5px", marginTop: "55px" }}>Sweet! Rookout desktop app</Text>
+          <Text style={{ marginTop: 0 }}>is up and running in the background</Text>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixing the "Sweet! Rookout desktop app..." message, as it had the word "and" twice.

Before:
![image](https://user-images.githubusercontent.com/95576653/173770431-25e920da-278c-4222-b3f7-89667f62f3ba.png)


After:
![image](https://user-images.githubusercontent.com/95576653/173770335-de462d0c-82b2-41c8-944b-5ad77280eebb.png)
