### PR TITLE
RK-12668 - Improve headless mode flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.8.41",
+  "version": "1.8.42",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {
@@ -14,6 +14,7 @@
     "build-packages-all-distributions": "export ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=true && electron-builder --mac --win --linux -p always",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "cross-env development=1 yarn run build && cross-env development=1 electron ./dist/index.js",
+    "start-headless": "yarn run build-headless && node ./dist/headless.js -p=44512",
     "debug": "cross-env development=1 $NODE_DEBUG_OPTION yarn run build && cross-env development=1 electron --inspect-brk ./dist/index.js"
   },
   "build": {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -8,32 +8,35 @@ import * as graphQlServer from "./server";
 
 const args = require("args-parser")(process.argv);
 
-if (args.help || !args.repo) {
-    console.log("add repository using --repo=<name>,<path>");
+if (args.help || args.h) {
+    console.log("add repository using --repo=<name>,<path> or -r=<name>,<path>");
     console.log("customize listen port with --port or -p");
     console.log("customize access token with --token");
     process.exit(0);
 }
 
-let repos = [];
+if (args.repo || args.r) {
+    const repoArg = args.repo || args.r;
+    let repos;
 
-try { // Allow for multiple repos as an array of objects
-    repos = JSON.parse(args.repo);
-} catch (err) {
-    const arr = args.repo.split(",");
-    const { name, path } = { name: arr[0], path: arr[1] };
-    repos = [{ name, path }];
-}
+    try { // Allow for multiple repos as an array of objects
+        repos = JSON.parse(repoArg);
+    } catch (err) {
+        const arr = repoArg.split(",");
+        const { name, path } = { name: arr[0], path: arr[1] };
+        repos = [{ name, path }];
+    }
 
-repos.forEach((repo: any) => {
-    repStore.add({
-        fullpath: repo.path,
-        repoName: repo.name,
-        id: undefined,
-    }).catch((err) => {
-        throw err;
+    repos.forEach((repo: any) => {
+        repStore.add({
+            fullpath: repo.path,
+            repoName: repo.name,
+            id: undefined,
+        }).catch((err) => {
+            throw err;
+        });
     });
-});
+}
 
 process.on("uncaughtException", (error) => {
     console.error("unhandled exception thrown", error);


### PR DESCRIPTION
* Fix the repo flag in headless mode optional. 
* Add a basic start-headless script. 
* Add short versions of some flags of headless (h is like help, r is like repo).

Tested running in headless mode using the new flag names and without the repo/r flag.