### PR TITLE
RK-12672 - Upgrade the macOS image in circle ci so the node version will be 16.14.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
 jobs:
   publish:
     macos:
-      xcode: "12.4.0"
+      xcode: "13.3.1"
     steps:
       - checkout
       - restore_cache:
@@ -59,7 +59,7 @@ jobs:
             - /usr/local/Homebrew
   version_validation:
     macos:
-      xcode: "12.4.0"
+      xcode: "13.3.1"
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Upgrade the macOS image in circle ci so the node version will be 16.14.2.

Version list is [here](https://circleci.com/docs/2.0/testing-ios/)