### PR TITLE
RK-12928 - Improve go and python language servers for linux, macOS and windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/langauge-servers/configStore.ts
+++ b/src/langauge-servers/configStore.ts
@@ -189,14 +189,12 @@ class LangServerConfigStore {
 
     private isPythonLSInstalled() {
         const pipLocation = getPipLocationFromPythonDirectory(this.serverLocations["python"]);
-        const { stdout, stderr } = cp.spawnSync(
+        const { stderr } = cp.spawnSync(
             PIP_EXEC_FILENAME,
             ["show", "python-lsp-server"],
             { cwd: pipLocation, encoding: "utf-8" }
         );
-        const trimmedError = _.trim(stderr);
-        const trimmedOutput = _.trim(stdout);
-        return _.includes(trimmedOutput, "Name: python-lsp-server") && !_.startsWith(trimmedError, "WARNING: Package(s) not found:");
+        return _.isEmpty(stderr);
     }
 
     private installPythonLS() {

--- a/src/langauge-servers/goUtils.ts
+++ b/src/langauge-servers/goUtils.ts
@@ -38,7 +38,7 @@ export const findGoLocation = (): GoRuntime[] => {
         console.log("Go - found candidate installation location", { goLocation });
 
         const goExecutable = path.join(goLocation, GO_EXEC_FILENAME);
-        if (fs.existsSync(goExecutable) && fs.lstatSync(goExecutable).isFile() || fs.lstatSync(goExecutable).isSymbolicLink()) {
+        if (fs.existsSync(goExecutable) && (fs.lstatSync(goExecutable).isFile() || fs.lstatSync(goExecutable).isSymbolicLink())) {
             const version = checkVersionByCLI(goLocation);
 
             if (version) {

--- a/src/langauge-servers/pythonUtils.ts
+++ b/src/langauge-servers/pythonUtils.ts
@@ -9,6 +9,7 @@ const isWindows = process.platform.match("win32");
 const isMac = process.platform.match("darwin");
 const isLinux = process.platform.match("linux");
 export const PYTHON_EXEC_FILENAME = isWindows ? "python.exe" : "python3";
+export const PIP_EXEC_FILENAME = isWindows ? "pip.exe" : "pip3";
 
 export interface PythonRuntime {
     location: string;
@@ -75,6 +76,15 @@ const fromCommonPlaces = (): string[] => {
     }
 
     return pythonLocations;
+};
+
+export const getPipLocationFromPythonDirectory = (pythonLocation: string): string => {
+    const pipExecLocation = isWindows ? path.join(pythonLocation, "Scripts", PIP_EXEC_FILENAME) : path.join(pythonLocation, PIP_EXEC_FILENAME);
+    if (fs.existsSync(pipExecLocation) && (fs.lstatSync(pipExecLocation).isFile() || fs.lstatSync(pipExecLocation).isSymbolicLink())) {
+        return path.dirname(pipExecLocation);
+    } else {
+        throw new Error("Pip not found");
+    }
 };
 
 export const getPythonVersion = (pythonExecutableFolder: string): string => checkVersionByCLI(pythonExecutableFolder);


### PR DESCRIPTION
Fix the way we find the go installation (use the unix common place for the goroot and add a check for the GOROOT env var). Improve the way we use pip