### PR TITLE
RK-13156 - Increase the indexer's limit and and add indexRunning to repo

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,6 +3,7 @@ type Repository {
   repoName: String!
   id: String!
   indexDone: Boolean
+  indexRunning: Boolean
   lastCommitDescription: CommitDescription
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,7 +3,7 @@ type Repository {
   repoName: String!
   id: String!
   indexDone: Boolean
-  indexRunning: Boolean
+  indexLimitReached: Boolean
   lastCommitDescription: CommitDescription
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/common/repository.ts
+++ b/src/common/repository.ts
@@ -1,17 +1,9 @@
-import * as git from "isomorphic-git";
-
 export interface Repository {
     repoName: string;
     fullpath: string;
     id: string;
     indexDone?: boolean;
+    indexRunning?: boolean;
     listTree?(): string[];
     reIndex?(): void;
-}
-
-export interface RepositoryV3 {
-    repoName: string;
-    fullpath: string;
-    id: string;
-    indexDone?: boolean;
 }

--- a/src/common/repository.ts
+++ b/src/common/repository.ts
@@ -3,7 +3,7 @@ export interface Repository {
     fullpath: string;
     id: string;
     indexDone?: boolean;
-    indexRunning?: boolean;
+    indexLimitReached?: boolean;
     listTree?(): string[];
     reIndex?(): void;
 }

--- a/src/fsIndexer.ts
+++ b/src/fsIndexer.ts
@@ -9,7 +9,7 @@ const defaultIgnores = [/\.git/, /\.svn/, /\.hg/, /CVS/, /\.DS_Store/,
     /\.project/, /\.cache/, /\.gradle/, /\.idea/, /\.kube/, /\.vscode/, /\.history/, /\.eggs/];
 const ignoreRegex = /.*(\.pyc|\.class|\.jar|\.svg|\.png|\.mxml|\.html|\.css|\.scss|\.dll|\.pdb|\.exe|\.csproj|\.txt|\.xml)$/i;
 // TODO: check performance to the limit and increase as necessary
-const listLimit = 50000;
+const listLimit = 300_000;
 
 // This worker used to index all the filenames in the repository
 // but we changed it to just keep a list of all the files instead.

--- a/src/repoStore.ts
+++ b/src/repoStore.ts
@@ -53,7 +53,7 @@ export class Repo {
             fullpath: this.fullpath,
             id: this.id,
             indexDone: this.indexer.indexDone,
-            indexRunning: this.indexer.indexRunning
+            indexLimitReached: !this.indexer.indexDone && !this.indexer.indexRunning
         };
     }
 }

--- a/src/repoStore.ts
+++ b/src/repoStore.ts
@@ -53,6 +53,7 @@ export class Repo {
             fullpath: this.fullpath,
             id: this.id,
             indexDone: this.indexer.indexDone,
+            indexRunning: this.indexer.indexRunning
         };
     }
 }


### PR DESCRIPTION
Increase the indexer's limit to 300k files (file paths) and add indexRunning to the repo object