### PR TITLE
RK-13422 - Update the patch instructions of pull requests

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-If this PR is updating explrook behavior even in the most minimal way, please bump up the version in `package.json`.
+Before merging the PR, please bump up the version in `package.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
If a PR does not update the project's version. The CI/CD fails and bumps the veraion with a direct commit to master.

Therefore, in order to avoid this kind of a mess, I updated the PR instructions of the project to state that the version ALWAYS needs to be bumped up.