### PR TITLE
RK-13571 - Upgrade electron to 19.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {
@@ -98,7 +98,7 @@
     "aws-lambda": "^1.0.5",
     "copyfiles": "^2.3.0",
     "cross-env": "^5.2.0",
-    "electron": "19.0.4",
+    "electron": "19.0.13",
     "electron-builder": "23.1.0",
     "electron-notarize": "1.2.1",
     "graphql-middleware": "6.1.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,10 +2814,10 @@ electron-updater@^4.2.2:
     lodash.isequal "^4.5.0"
     semver "^7.3.2"
 
-electron@19.0.4:
-  version "19.0.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.4.tgz#a88d5e542868c4abd7704228ec62c553605605a0"
-  integrity sha512-roRYr1VNAWIhjD9n8qZdmhROtrzsFpuZEXrjWAw+GqPbZlrUInmvFCviRDC2Lt+VBsTNRpTfPpfzXSlLL4reEw==
+electron@19.0.13:
+  version "19.0.13"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.13.tgz#68bcf7d94f249dbae9a3d4d1794d45a24db666dc"
+  integrity sha512-11Ne0VJy8L1GU7sGcbJHhkAz73szR27uP4vmfUVGlppC/ipA39AUkdzqiQoPC/F1EJdjEOBvHySG8K8Xe9yETA==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
Upgrade electron to the latest patch of major version 19 to fix vulns and bugs

Tests:
Sanity tests for:
Normal Desktop App Usage
Bitbucket On Prem
Java + Python Language servers