### PR TITLE
RK-13748 - Use the supported tool (notarytool) to notarize the app for macOS

### DIFF
--- a/afterSignHook.js
+++ b/afterSignHook.js
@@ -33,6 +33,7 @@ module.exports = async function (params) {
             appPath: appPath,
             appleId: process.env.appleId,
             appleIdPassword: process.env.appleIdPassword,
+            tool: "notarytool" // This will prevent using the legacy altool to notarize (will be shut down by 2023)
         });
     } catch (error) {
         console.error(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Use the supported tool (notarytool) to notarize the app for macOS.
(Use notarytool instead of the deprecated altool)
Should solve this error:
Warning: altool has been deprecated and, starting in fall 2023, will no longer be supported by the Apple notary service. You should start using notarytool to notarize your software.