### PR TITLE
RK-15775 - Add OS Info to Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.12.5",
+  "version": "1.13.0",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,12 @@ import * as log from "electron-log";
 import * as Store from "electron-store";
 import {autoUpdater, UpdateInfo} from "electron-updater";
 import fs = require("fs");
-import { userInfo } from "os";
+import {
+  arch as operatingSystemArch,
+  platform as operatingSystemPlatform,
+  userInfo,
+  version as operatingSystemVersion
+} from "os";
 import * as path from "path";
 import {deeplinkHandler, initDeeplinks} from "./deeplinks";
 import { ExplorookStore } from "./explorook-store";
@@ -195,7 +200,10 @@ function flushAnalytics(callback: () => void) {
 
 function identifyAnalytics() {
   const { username } = userInfo();
-  analytics.identify({ userId, traits: { username } });
+  const osArch = operatingSystemArch();
+  const osPlatform = operatingSystemPlatform();
+  const osVersion = operatingSystemVersion();
+  analytics.identify({ userId, traits: { username, osPlatform, osArch, osVersion } });
 }
 
 function initAnalytics() {


### PR DESCRIPTION
Add OS info to analytics.
This is due to the upcoming end of support for windows 7+8 in chromium and electron