### PR TITLE
RK-19787 - Bitbucket OnPrem - Fix Lazy Loading Edge Case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/BitBucketOnPrem.ts
+++ b/src/BitBucketOnPrem.ts
@@ -202,8 +202,21 @@ export const getFileTreeByPath =
             if (Array.isArray(values)) {
                 for (const item of values) {
                     const { type, path } = item;
-                    const { name } = path || {};
-                    files.push(`${name}${type === FILE_TYPE.DIRECTORY ? "/" : ""}`);
+                    // toString (which is a string prop) is important, such as in cases where a child is a folder
+                    // that recursively has single child that is a folder.
+                    // In that case, we get the folder that is in the bottom of this subtree as a direct child.
+                    // The way we get it is that name is the name of the dir itself,
+                    // but toString is path to it relative to the path we fetch its children
+                    // If this is a normal folder or file, toString and name are the same
+                    // Therefore, fetching the file as toString is preferable to name
+                    // Example:
+                    // -- Dir1
+                    // -- -- Dir2
+                    // -- -- -- Dir3
+                    // -- -- -- -- File-not-in-this-response-because-call-is-lazy-fetching.txt
+                    // In this example: { name: 'Dir3', toString: 'Dir1/Dir2/Dir3' }
+                    const { name, toString } = path || {};
+                    files.push(`${toString || name}${type === FILE_TYPE.DIRECTORY ? "/" : ""}`);
                 }
             } else {
                 notify("Bitbucket OnPrem files tree request returned an unexpected value", {metaData: {resStatus: res.status, fileTreeResponse}});


### PR DESCRIPTION
Fixed issue related to lazy fetching of folders that recursively have only one folder as child.

In bitbucket on prem, such folders are fetched at once, as in, in the example below, when Dir1 is lazy loaded, everything until Dir3 will be fetched (as in, dir3 will need to be lazy loaded to get the files, but everything up to it including the dir itself will be added to the tree).

This fix makes sure the relative path of the bottom folder is returned instead of its name, so that the frontend is able to properly fetch it by knowing its path in the repo.

Example of a path that had an issue being lazy loaded:
```
-- Dir1
-- -- Dir2
-- -- -- Dir3
-- -- -- -- File-not-here-because-fetched-when-dir3-lazy-loaded.txt
```