### PR TITLE
RK-20569 - CORS rework for Dynatrace apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorook",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "description": "Rookout's site addon to support local files and folders",
   "main": "dist/index.js",
   "scripts": {

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,5 +1,6 @@
 import type {CorsOptions, CorsRequest} from "cors";
 import * as cors from "cors";
+import fetch from "node-fetch";
 
 
 const LOCALHOST_ORIGIN = "https://localhost:8080";
@@ -9,18 +10,31 @@ const DYNATRACE_ORIGIN_REGEX = /^https:\/\/.*\.dynatrace(?:labs)?\.com$/;
 const ALLOW_CORS_OPTION: CorsOptions = {origin: true};
 const DENY_CORS_OPTION: CorsOptions = {origin: false};
 
+
+const verifiedOriginsCache = new Set([LOCALHOST_ORIGIN]);
+
+
 const corsOptionsDelegate = async (req: CorsRequest, callback: (err: Error | null, options?: CorsOptions) => void) => {
     try {
         const origin = req.headers.origin;
-        if (origin === LOCALHOST_ORIGIN || ROOKOUT_ORIGIN_REGEX.test(origin)) {
+        if (verifiedOriginsCache.has(origin) || ROOKOUT_ORIGIN_REGEX.test(origin)) {
             callback(null, ALLOW_CORS_OPTION);
             return;
         }
 
         if (!DYNATRACE_ORIGIN_REGEX.test(origin)) {
             callback(null, DENY_CORS_OPTION);
+            return;
         }
 
+        const response = await fetch(`${origin}/platform-reserved/dob/isapprefallowed?appOrigin=${origin}`);
+
+        if (!response.ok) {
+            callback(null, DENY_CORS_OPTION);
+            return;
+        }
+
+        verifiedOriginsCache.add(origin);
         callback(null, ALLOW_CORS_OPTION);
     } catch (err) {
         callback(err, DENY_CORS_OPTION);

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,6 +1,7 @@
 import type {CorsOptions, CorsRequest} from "cors";
 import * as cors from "cors";
 import fetch from "node-fetch";
+import {getStoreSafe} from "./explorook-store";
 
 
 const LOCALHOST_ORIGIN = "https://localhost:8080";
@@ -13,6 +14,7 @@ const DENY_CORS_OPTION: CorsOptions = {origin: false};
 
 const verifiedOriginsCache = new Set([LOCALHOST_ORIGIN]);
 
+const store = getStoreSafe();
 
 const corsOptionsDelegate = async (req: CorsRequest, callback: (err: Error | null, options?: CorsOptions) => void) => {
     try {
@@ -26,6 +28,13 @@ const corsOptionsDelegate = async (req: CorsRequest, callback: (err: Error | nul
             callback(null, DENY_CORS_OPTION);
             return;
         }
+
+        const shouldSkipDtVerification = store.get("skipDtVerification", false);
+        if (shouldSkipDtVerification) {
+            callback(null, ALLOW_CORS_OPTION);
+            return;
+        }
+
 
         const response = await fetch(`${origin}/platform-reserved/dob/isapprefallowed?appOrigin=${origin}`);
 

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,34 @@
+import type {CorsOptions, CorsRequest} from "cors";
+import * as cors from "cors";
+
+
+const LOCALHOST_ORIGIN = "https://localhost:8080";
+const ROOKOUT_ORIGIN_REGEX = /^https:\/\/.*\.rookout(?:-dev)?\.com$/;
+const DYNATRACE_ORIGIN_REGEX = /^https:\/\/.*\.dynatrace(?:labs)?\.com$/;
+
+const ALLOW_CORS_OPTION: CorsOptions = {origin: true};
+const DENY_CORS_OPTION: CorsOptions = {origin: false};
+
+const corsOptionsDelegate = async (req: CorsRequest, callback: (err: Error | null, options?: CorsOptions) => void) => {
+    try {
+        const origin = req.headers.origin;
+        if (origin === LOCALHOST_ORIGIN || ROOKOUT_ORIGIN_REGEX.test(origin)) {
+            callback(null, ALLOW_CORS_OPTION);
+            return;
+        }
+
+        if (!DYNATRACE_ORIGIN_REGEX.test(origin)) {
+            callback(null, DENY_CORS_OPTION);
+        }
+
+        callback(null, ALLOW_CORS_OPTION);
+    } catch (err) {
+        callback(err, DENY_CORS_OPTION);
+    }
+};
+
+
+export const getCorsMiddleware = () => {
+    return cors(corsOptionsDelegate);
+};
+

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,23 +1,23 @@
-import type {CorsOptions, CorsRequest} from "cors";
 import * as cors from "cors";
 import fetch from "node-fetch";
-import {getStoreSafe} from "./explorook-store";
+import { getStoreSafe } from "./explorook-store";
 
 
 const LOCALHOST_ORIGIN = "https://localhost:8080";
 const ROOKOUT_ORIGIN_REGEX = /^https:\/\/.*\.rookout(?:-dev)?\.com$/;
 const DYNATRACE_ORIGIN_REGEX = /^https:\/\/.*\.dynatrace(?:labs)?\.com$/;
 
-const ALLOW_CORS_OPTION: CorsOptions = {origin: true};
-const DENY_CORS_OPTION: CorsOptions = {origin: false};
+const ALLOW_CORS_OPTION: cors.CorsOptions = {origin: true};
+const DENY_CORS_OPTION: cors.CorsOptions = {origin: false};
 
 
 const verifiedOriginsCache = new Set([LOCALHOST_ORIGIN]);
 
 const store = getStoreSafe();
 
-const corsOptionsDelegate = async (req: CorsRequest, callback: (err: Error | null, options?: CorsOptions) => void) => {
+const corsOptionsDelegate = async (req: cors.CorsRequest, callback: (err: Error | null, options?: cors.CorsOptions) => void) => {
     try {
+        const shouldSkipDtVerification = store.get("skipDtVerification", false);
         const origin = req.headers.origin;
         if (verifiedOriginsCache.has(origin) || ROOKOUT_ORIGIN_REGEX.test(origin)) {
             callback(null, ALLOW_CORS_OPTION);
@@ -29,7 +29,7 @@ const corsOptionsDelegate = async (req: CorsRequest, callback: (err: Error | nul
             return;
         }
 
-        const shouldSkipDtVerification = store.get("skipDtVerification", false);
+
         if (shouldSkipDtVerification) {
             callback(null, ALLOW_CORS_OPTION);
             return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,10 +33,8 @@ const defaultOptions: StartOptions = {
 };
 
 const corsDomainWhitelist = [
-  /^https:\/\/.*\.rookout\.com$/,
-  /^https:\/\/.*\.rookout-dev\.com$/,
-  /^https:\/\/.*\.dynatracelabs\.com$/,
-  /^https:\/\/.*\.dynatrace\.com$/,
+  /^https:\/\/.*\.rookout(-dev)?\.com$/,
+  /^https:\/\/.*\.dynatrace(labs)?\.com$/,
   "https://localhost:8080"
 ];
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,13 +2,13 @@ import { makeExecutableSchema } from "@graphql-tools/schema";
 import { ApolloServerPluginLandingPageDisabled } from "apollo-server-core";
 import { ApolloServer } from "apollo-server-express";
 import * as bodyParser from "body-parser";
-import * as cors from "cors";
 import * as express from "express";
 import { readFileSync } from "fs";
 import { applyMiddleware } from "graphql-middleware";
 import * as http from "http";
 import { join } from "path";
 import { resolvers } from "./api";
+import {getCorsMiddleware} from "./cors";
 import { notify } from "./exceptionManager";
 import {
   filterDirTraversal,
@@ -32,15 +32,6 @@ const defaultOptions: StartOptions = {
   port: 44512
 };
 
-const corsDomainWhitelist = [
-  /^https:\/\/.*\.rookout(-dev)?\.com$/,
-  /^https:\/\/.*\.dynatrace(labs)?\.com$/,
-  "https://localhost:8080"
-];
-
-const corsOptions = {
-  origin: corsDomainWhitelist
-};
 
 export const start = async (options: StartOptions) => {
   const settings = { ...options, ...defaultOptions };
@@ -69,7 +60,7 @@ export const start = async (options: StartOptions) => {
     cache: "bounded"
   });
 
-  app.use(cors(corsOptions));
+  app.use(getCorsMiddleware());
   app.use(bodyParser.json());
 
   await apolloServer.start();

--- a/src/webapp/src/components/Header.js
+++ b/src/webapp/src/components/Header.js
@@ -25,12 +25,19 @@ export const Header = () => {
 
     const store = new Store({ name: "explorook" });
     const isLogLevelDebug = store.get("logLevel", "debug") === "debug";
+    const shouldSkipDtVerification = store.get("skipDtVerification", false);
+
     const setLogLever = isDebug => {
         ipcRenderer.sendTo(window.indexWorkerId, "set-log-level", isDebug ? "debug" : "error")
         setOpen(false);
     }
     const clearAllRepos = () => {
         ipcRenderer.sendTo(window.indexWorkerId, "clear-all-repos");
+        setOpen(false);
+    }
+
+    const toggleShouldSkipDtVerification = () => {
+        store.set('skipDtVerification', !shouldSkipDtVerification);
         setOpen(false);
     }
 
@@ -43,6 +50,7 @@ export const Header = () => {
                     <MenuItem key="debug" onClick={startDebug}>Debug</MenuItem>
                     <MenuItem key="log-level" onClick={() => setLogLever(!isLogLevelDebug)}>{isLogLevelDebug ? "Error Logs" : "Debug Logs"}</MenuItem>
                     <MenuItem key="remove-all-repos" onClick={clearAllRepos}>Clear data</MenuItem>
+                    <MenuItem key="toggle-skip-verification" onClick={toggleShouldSkipDtVerification}>{shouldSkipDtVerification ? 'Enable' : 'Skip'} Verification {!shouldSkipDtVerification && '(Unsafe)'}</MenuItem>
                     <MenuItem key="close" onClick={() => setOpen(false)}>Close</MenuItem>
                 </Menu>
             </div>


### PR DESCRIPTION
This PR reworks how CORS is handled for Dynatrace apps.

If request is coming from a valid Dynatrace URL, it will check against the origin's environment facade that the Dynatrace app ref is allowed to access the Desktop app.
