### PR TITLE
RK-20853 - CircleCI - Install rosetta to avoid bad CPU error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
     resource_class: macos.m1.medium.gen1
     steps:
       - checkout
+      - macos/install-rosetta
       - restore_cache:
           key: homebrew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}-{{ checksum ".circleci/config.yml" }}
       - run:


### PR DESCRIPTION
According to this [this](https://support.circleci.com/hc/en-us/articles/21521502906267-Why-am-I-seeing-Bad-CPU-type-in-executable-errors-when-running-CircleCI-Builds-on-Apple-Silicon), adding this step should solve the bad CPU type errors we're having since migrating to M1 machines in CircleCI

![image](https://github.com/user-attachments/assets/613a8a73-bde2-456a-be15-9ca642d3eb05)
